### PR TITLE
Don't require sentry 2.1, allow any 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     {
         "php": ">=5.3.0",
         "illuminate/support": "4.0.*",
-        "cartalyst/sentry": "2.1.*"
+        "cartalyst/sentry": "~2"
     },
     "require-dev": {
         "illuminate/database": "4.0.*"


### PR DESCRIPTION
Don't require sentry 2.1, allow any 2.x version.
