### PR TITLE
fix markup in example

### DIFF
--- a/docs/custom.md
+++ b/docs/custom.md
@@ -98,7 +98,7 @@ View ```left-nav.blade.php``` example :
 
     <li class=""><a href=""><i class="glyphicon glyphicon-home"></i> <span>Home</span></a></li>
     <li class="dropdown" >
-        <a class="dropdown-toggle" data-toggle="dropdown" href="#"><i class="glyphicon glyphicon-home"></i><span>Blog</span></a></a>
+        <a class="dropdown-toggle" data-toggle="dropdown" href="#"><i class="glyphicon glyphicon-home"></i> <span>Blog</span></a>
         <ul class="dropdown-menu">
             <li><a href="">Articles</a></li>
             <li><a href="">Comments</a></li>


### PR DESCRIPTION
a very minor change: Duplicate </a> removed and blank added to make sure there's a gap between the icon and the text
