### PR TITLE
show comma separated list instead of JSON string to end-user

### DIFF
--- a/src/views/group/list-groups.blade.php
+++ b/src/views/group/list-groups.blade.php
@@ -25,7 +25,7 @@
         </td>
         <td style="text-align: center;">{{ $group->getId() }}</td>
         <td>{{ $group->getName() }}</td>
-        <td>{{ json_encode($group->getPermissions()) }}</td>
+        <td>{{ join(', ', array_keys($group->getPermissions())) }}</td>
         <td style="text-align: center;">&nbsp;<a href="{{ URL::route('showGroup', $group->getId())}}">{{ trans('syntara::all.show') }}</a></td>
     </tr>
     @endforeach

--- a/src/views/user/list-users.blade.php
+++ b/src/views/user/list-users.blade.php
@@ -51,7 +51,7 @@
             {{ $group['name'] }},
         @endforeach
         </td>
-        <td class="hidden-xs">{{ json_encode($user->getPermissions()) }}</td>
+        <td class="hidden-xs">{{ join(', ', array_keys($user->getPermissions())) }}</td>
         <td class="visible-lg">&nbsp;{{ $user->last_name }}</td>
         <td class="visible-lg">&nbsp;{{ $user->first_name }}</td>
         <td class="hidden-xs">{{ $user->isActivated() ? trans('syntara::all.yes') : '<a class="activate-user" href="#" data-toggle="tooltip" title="'.trans('syntara::users.activate').'">'.trans('syntara::all.no').'</a>'}}</td>


### PR DESCRIPTION
I'd recommend to display a comma separated list instead of a JSON object to end-users.
