### PR TITLE
User list display change

### DIFF
--- a/src/views/user/list-users.blade.php
+++ b/src/views/user/list-users.blade.php
@@ -45,7 +45,7 @@
         @endif
         <td class="hidden-xs" style="text-align: center;">{{ $user->getId() }}</td>
         <td >&nbsp;{{ $user->username }}</td>
-        <td class="visible-xs visible-lg">&nbsp;{{ $user->getLogin() }}</td>
+        <td class="visible-xs visible-lg">&nbsp;{{ $user->email }}</td>
         <td class="hidden-xs">
         @foreach($user->getGroups()->toArray() as $key => $group)
             {{ $group['name'] }},


### PR DESCRIPTION
If you ever modify sentry to use `username` as the login attribute, the user list will display the username in both `Email` and `Username` table columns.
